### PR TITLE
Use redox-syscall for isatty on Redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ kernel32-sys = "0.2"
 winapi = "0.2"
 
 [target.'cfg(target_os = "redox")'.dependencies]
-termion = "1.5"
+redox_syscall = "0.1"


### PR DESCRIPTION
We don't need the whole termios to implement `isatty`.
I extracted the implementation from [`is_tty` in termion](https://github.com/ticki/termion/blob/master/src/sys/redox/tty.rs#L7).