### PR TITLE
Raise minimum supported rustc version to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: rust
 
 rust:
-  - 1.9.0
+  - 1.11.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
This is forced by https://github.com/rust-lang/libc/pull/972.