### PR TITLE
Enable compilation on wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 travis-ci = { repository = "dtolnay/isatty" }
 appveyor = { repository = "dtolnay/isatty" }
 
+[dependencies]
+cfg-if = "0.1"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,136 +48,124 @@
 
 #![doc(html_root_url = "https://docs.rs/isatty/0.1.8")]
 
+#[macro_use]
+extern crate cfg_if;
+
 // Based on:
 //  - https://github.com/rust-lang/cargo/blob/099ad28104fe319f493dc42e0c694d468c65767d/src/cargo/lib.rs#L154-L178
 //  - https://github.com/BurntSushi/ripgrep/issues/94#issuecomment-261761687
 
 #[cfg(not(windows))]
 pub fn stdin_isatty() -> bool {
-    isatty(stream::Stream::Stdin)
+    isatty(Stream::Stdin)
 }
 
 pub fn stdout_isatty() -> bool {
-    isatty(stream::Stream::Stdout)
+    isatty(Stream::Stdout)
 }
 
 pub fn stderr_isatty() -> bool {
-    isatty(stream::Stream::Stderr)
+    isatty(Stream::Stderr)
 }
 
-mod stream {
-    pub enum Stream {
-        #[cfg(not(windows))]
-        Stdin,
-        Stdout,
-        Stderr,
-    }
+enum Stream {
+    #[cfg(not(windows))]
+    Stdin,
+    Stdout,
+    Stderr,
 }
 
-#[cfg(unix)]
-use unix::isatty;
-#[cfg(unix)]
-mod unix {
-    use stream::Stream;
+cfg_if! {
+    if #[cfg(unix)] {
+        fn isatty(stream: Stream) -> bool {
+            extern crate libc;
 
-    pub fn isatty(stream: Stream) -> bool {
-        extern crate libc;
+            let fd = match stream {
+                Stream::Stdin => libc::STDIN_FILENO,
+                Stream::Stdout => libc::STDOUT_FILENO,
+                Stream::Stderr => libc::STDERR_FILENO,
+            };
 
-        let fd = match stream {
-            Stream::Stdin => libc::STDIN_FILENO,
-            Stream::Stdout => libc::STDOUT_FILENO,
-            Stream::Stderr => libc::STDERR_FILENO,
-        };
-
-        unsafe { libc::isatty(fd) != 0 }
-    }
-}
-
-#[cfg(windows)]
-use windows::isatty;
-#[cfg(windows)]
-mod windows {
-    extern crate winapi;
-
-    use stream::Stream;
-
-    pub fn isatty(stream: Stream) -> bool {
-        let handle = match stream {
-            Stream::Stdout => winapi::um::winbase::STD_OUTPUT_HANDLE,
-            Stream::Stderr => winapi::um::winbase::STD_ERROR_HANDLE,
-        };
-
-        unsafe {
-            let handle = winapi::um::processenv::GetStdHandle(handle);
-
-            // check for msys/cygwin
-            if is_cygwin_pty(handle) {
-                return true;
-            }
-
-            let mut out = 0;
-            winapi::um::consoleapi::GetConsoleMode(handle, &mut out) != 0
+            unsafe { libc::isatty(fd) != 0 }
         }
-    }
+    } else if #[cfg(windows)] {
+        extern crate winapi;
 
-    /// Returns true if there is an MSYS/cygwin tty on the given handle.
-    fn is_cygwin_pty(handle: winapi::um::winnt::HANDLE) -> bool {
-        use std::ffi::OsString;
-        use std::mem;
-        use std::os::windows::ffi::OsStringExt;
-        use std::slice;
+        fn isatty(stream: Stream) -> bool {
+            let handle = match stream {
+                Stream::Stdout => winapi::um::winbase::STD_OUTPUT_HANDLE,
+                Stream::Stderr => winapi::um::winbase::STD_ERROR_HANDLE,
+            };
 
-        use self::winapi::um::winbase::GetFileInformationByHandleEx;
-        use self::winapi::um::fileapi::FILE_NAME_INFO;
-        use self::winapi::um::minwinbase::FileNameInfo;
-        use self::winapi::shared::minwindef::MAX_PATH;
-        use self::winapi::shared::minwindef::LPVOID;
+            unsafe {
+                let handle = winapi::um::processenv::GetStdHandle(handle);
 
-        unsafe {
-            let size = mem::size_of::<FILE_NAME_INFO>();
-            let mut name_info_bytes = vec![0u8; size + MAX_PATH];
-            let res = GetFileInformationByHandleEx(handle,
-                                                FileNameInfo,
-                                                &mut *name_info_bytes as *mut _ as LPVOID,
-                                                name_info_bytes.len() as u32);
-            if res == 0 {
-                return true;
+                // check for msys/cygwin
+                if is_cygwin_pty(handle) {
+                    return true;
+                }
+
+                let mut out = 0;
+                winapi::um::consoleapi::GetConsoleMode(handle, &mut out) != 0
             }
-            let name_info: FILE_NAME_INFO = *(name_info_bytes[0..size]
-                .as_ptr() as *const FILE_NAME_INFO);
-            let name_bytes = &name_info_bytes[size..size + name_info.FileNameLength as usize];
-            let name_u16 = slice::from_raw_parts(name_bytes.as_ptr() as *const u16,
-                                                name_bytes.len() / 2);
-            let name = OsString::from_wide(name_u16)
-                .as_os_str()
-                .to_string_lossy()
-                .into_owned();
-            name.contains("msys-") || name.contains("-pty")
         }
-    }
-}
 
-#[cfg(target_os = "redox")]
-use redox::isatty;
-#[cfg(target_os = "redox")]
-mod redox {
-    use stream::Stream;
+        /// Returns true if there is an MSYS/cygwin tty on the given handle.
+        fn is_cygwin_pty(handle: winapi::um::winnt::HANDLE) -> bool {
+            use std::ffi::OsString;
+            use std::mem;
+            use std::os::windows::ffi::OsStringExt;
+            use std::slice;
 
-    pub fn isatty(stream: Stream) -> bool {
-        extern crate syscall;
-        use std::io;
-        use std::os::unix::io::AsRawFd;
+            use self::winapi::um::winbase::GetFileInformationByHandleEx;
+            use self::winapi::um::fileapi::FILE_NAME_INFO;
+            use self::winapi::um::minwinbase::FileNameInfo;
+            use self::winapi::shared::minwindef::MAX_PATH;
+            use self::winapi::shared::minwindef::LPVOID;
 
-        let raw_fd = match stream {
-            Stream::Stdin => io::stdin().as_raw_fd(),
-            Stream::Stdout => io::stdout().as_raw_fd(),
-            Stream::Stderr => io::stderr().as_raw_fd(),
-        };
+            unsafe {
+                let size = mem::size_of::<FILE_NAME_INFO>();
+                let mut name_info_bytes = vec![0u8; size + MAX_PATH];
+                let res = GetFileInformationByHandleEx(handle,
+                                                    FileNameInfo,
+                                                    &mut *name_info_bytes as *mut _ as LPVOID,
+                                                    name_info_bytes.len() as u32);
+                if res == 0 {
+                    return true;
+                }
+                let name_info: FILE_NAME_INFO = *(name_info_bytes[0..size]
+                    .as_ptr() as *const FILE_NAME_INFO);
+                let name_bytes = &name_info_bytes[size..size + name_info.FileNameLength as usize];
+                let name_u16 = slice::from_raw_parts(name_bytes.as_ptr() as *const u16,
+                                                    name_bytes.len() / 2);
+                let name = OsString::from_wide(name_u16)
+                    .as_os_str()
+                    .to_string_lossy()
+                    .into_owned();
+                name.contains("msys-") || name.contains("-pty")
+            }
+        }
+    } else if #[cfg(target_os = "redox")] {
+        fn isatty(stream: Stream) -> bool {
+            extern crate syscall;
+            use std::io;
+            use std::os::unix::io::AsRawFd;
 
-        if let Ok(fd) = syscall::dup(raw_fd, b"termios") {
-            let _ = syscall::close(fd);
-            true
-        } else {
+            let raw_fd = match stream {
+                Stream::Stdin => io::stdin().as_raw_fd(),
+                Stream::Stdout => io::stdout().as_raw_fd(),
+                Stream::Stderr => io::stderr().as_raw_fd(),
+            };
+
+            if let Ok(fd) = syscall::dup(raw_fd, b"termios") {
+                let _ = syscall::close(fd);
+                true
+            } else {
+                false
+            }
+        }
+    } else {
+        fn isatty(_: Stream) -> bool {
             false
         }
     }


### PR DESCRIPTION
This commit adds support for `wasm32-unknown-unknown`, namely returning `false`
from all the functions. The current implementation strategy is to use the
`cfg-if` crate to cut down on the amount of boilerplate `#[cfg]` needed, but if
desired that it can always be added directly!